### PR TITLE
fix(pyproject): stop shipping the mike git dependency in package meta…

### DIFF
--- a/.github/workflows/doc dev.yml
+++ b/.github/workflows/doc dev.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install '.[doc]'
+          pip install git+https://github.com/squidfunk/mike.git
       - name: Setup Docs Deploy
         run: |
           git config --global user.name "Docs Deploy"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install '.[doc]'
+          pip install git+https://github.com/squidfunk/mike.git
       - name: Setup Docs Deploy
         run: |
           git config --global user.name "Docs Deploy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ Changelog = "https://github.com/quarkslab/pyrrha/CHANGELOG.md"
 pyrrha = 'pyrrha_mapper.__main__:pyrrha'
 
 [project.optional-dependencies]
-doc = ['black', 'mike @ git+https://github.com/squidfunk/mike.git', 'pymdown-extensions', "zensical"]
+doc = ['black', 'pymdown-extensions', "zensical"]
 linting = ['ruff']
 test = ['pytest', 'pytest-cov']
 typechecking = ['mypy']


### PR DESCRIPTION
…data

PyPI rejects any uploaded distribution whose metadata declares a direct URL/VCS dependency (PEP 508 direct reference), which blocked the v2.0.0 upload with a 400 Bad Request on 'mike @
git+https://github.com/squidfunk/mike.git' in the doc extra.

Zensical's versioning support requires a specific unpublished fork of mike (squidfunk/mike, not the real jimporter/mike on PyPI) and Zensical explicitly does not plan to publish it to PyPI, so pinning a released mike version is not an option here.

Drop mike from the packaged 'doc' extra entirely and install the fork directly in the two doc-deploy GitHub Actions workflows instead, which are the only places it's actually invoked.